### PR TITLE
Ekong Obie adding travis CI

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ekongobie/license-coverage-grader.svg?branch=master)](https://travis-ci.org/ekongobie/license-coverage-grader)
+
 # license-coverage-grader
 This is a tool which take an SPDX document and pointer to the original source files, and determine a "grade" score to quantify how complete the licensing information is at the file level for the code represented by the SPDX document.
 
@@ -140,4 +142,3 @@ GRADE:  F with 0.0 %  pass for files_with_any_kind_of_license_infos
 
 
 ```
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+
+language: python
+
+python:
+  - 2.7
+
+cache: pip
+
+script:
+  - pip install --editable .


### PR DESCRIPTION
### Description
I have added the travis CI build image link in the README.md. However the travis image comes from my forked instance of license coverage grader.
I also added a basic travis.yml file. And I noticed that the repository does not have a good test coverage; so, in the script section of the travis file, I was compelled to add the command to install the package.

Fixes #13 
